### PR TITLE
Add Power BI API client modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
-# pbapi
-Tool to call pbi api
+# Power BI API Client
+
+A lightweight Python client for interacting with the Power BI REST API. The
+library provides simple, object-oriented helpers to authenticate, list
+workspaces, fetch datasets and inspect data models.
+
+## Installation
+
+Create a virtual environment and install the dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Configuration
+
+Authentication details are read from environment variables. Create a `.env`
+file or export the following variables in your environment:
+
+```
+POWERBI_TENANT_ID=<your-tenant-id>
+POWERBI_CLIENT_ID=<your-client-id>
+POWERBI_CLIENT_SECRET=<your-client-secret>
+```
+
+The client authenticates using an Azure AD service principal via the
+`msal` library.
+
+## Example Usage
+
+Run the example script to list workspaces and datasets:
+
+```bash
+python examples/example_usage.py
+```
+
+This will output a table of your Power BI workspaces and datasets using
+`pandas` DataFrames.
+
+## Extending
+
+The codebase is structured to be easily extended for additional Power BI
+endpoints. Each entity class contains two core methods:
+
+* `get_raw` - fetch raw JSON data from the API.
+* `to_dataframe` - return the data as a `pandas` DataFrame for analysis.
+
+Additional helpers and endpoints can be implemented following the same
+pattern.

--- a/examples/example_usage.py
+++ b/examples/example_usage.py
@@ -1,0 +1,25 @@
+"""Example showing basic usage of the Power BI API client."""
+
+from powerbi_api_client import PowerBIAuth, Workspace, Dataset
+
+
+def main() -> None:
+    # Load credentials from environment variables
+    auth = PowerBIAuth.from_env()
+
+    # List workspaces
+    workspace_client = Workspace(auth)
+    workspaces_df = workspace_client.to_dataframe()
+    print("Workspaces:")
+    print(workspaces_df)
+
+    if not workspaces_df.empty:
+        workspace_id = workspaces_df.loc[0, "id"]
+        dataset_client = Dataset(auth, workspace_id)
+        datasets_df = dataset_client.to_dataframe()
+        print(f"\nDatasets in workspace {workspace_id}:")
+        print(datasets_df)
+
+
+if __name__ == "__main__":
+    main()

--- a/powerbi_api_client/__init__.py
+++ b/powerbi_api_client/__init__.py
@@ -1,0 +1,15 @@
+"""Power BI API client."""
+
+from .auth import PowerBIAuth
+from .workspace import Workspace
+from .dataset import Dataset
+from .datamodel import DataModel
+from . import utils
+
+__all__ = [
+    "PowerBIAuth",
+    "Workspace",
+    "Dataset",
+    "DataModel",
+    "utils",
+]

--- a/powerbi_api_client/auth.py
+++ b/powerbi_api_client/auth.py
@@ -1,0 +1,60 @@
+"""Authentication utilities for Power BI API."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional, Dict
+
+from dotenv import load_dotenv
+import msal
+
+
+class PowerBIAuth:
+    """Handle authentication with Azure AD for Power BI."""
+
+    def __init__(
+        self,
+        tenant_id: str,
+        client_id: str,
+        client_secret: str,
+        scope: Optional[str] = None,
+    ) -> None:
+        self.tenant_id = tenant_id
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.scope = scope or "https://analysis.windows.net/powerbi/api/.default"
+        self._token: Optional[Dict[str, str]] = None
+        authority = f"https://login.microsoftonline.com/{self.tenant_id}"
+        self.app = msal.ConfidentialClientApplication(
+            client_id=self.client_id,
+            authority=authority,
+            client_credential=self.client_secret,
+        )
+
+    @classmethod
+    def from_env(cls) -> "PowerBIAuth":
+        """Create an auth handler using environment variables."""
+        load_dotenv()
+        tenant_id = os.getenv("POWERBI_TENANT_ID")
+        client_id = os.getenv("POWERBI_CLIENT_ID")
+        client_secret = os.getenv("POWERBI_CLIENT_SECRET")
+        if not all([tenant_id, client_id, client_secret]):
+            raise ValueError(
+                "Missing required environment variables: POWERBI_TENANT_ID, POWERBI_CLIENT_ID, POWERBI_CLIENT_SECRET"
+            )
+        return cls(tenant_id, client_id, client_secret)
+
+    def get_access_token(self) -> str:
+        """Return a valid access token."""
+        if not self._token or "access_token" not in self._token:
+            self._token = self.app.acquire_token_for_client(scopes=[self.scope])
+            if "access_token" not in self._token:
+                raise RuntimeError(f"Failed to obtain token: {self._token.get('error_description')}")
+        return self._token["access_token"]
+
+    def headers(self) -> Dict[str, str]:
+        """Return standard headers for API calls."""
+        return {
+            "Authorization": f"Bearer {self.get_access_token()}",
+            "Content-Type": "application/json",
+        }

--- a/powerbi_api_client/datamodel.py
+++ b/powerbi_api_client/datamodel.py
@@ -1,0 +1,31 @@
+"""Data model interactions for datasets."""
+
+from __future__ import annotations
+
+import requests
+import pandas as pd
+
+from .auth import PowerBIAuth
+
+
+class DataModel:
+    """Fetch tables within a dataset."""
+
+    BASE_URL = "https://api.powerbi.com/v1.0/myorg"
+
+    def __init__(self, auth: PowerBIAuth, workspace_id: str, dataset_id: str) -> None:
+        self.auth = auth
+        self.workspace_id = workspace_id
+        self.dataset_id = dataset_id
+
+    def get_raw(self) -> list[dict]:
+        """Return tables inside the dataset."""
+        url = f"{self.BASE_URL}/groups/{self.workspace_id}/datasets/{self.dataset_id}/tables"
+        response = requests.get(url, headers=self.auth.headers())
+        response.raise_for_status()
+        return response.json().get("value", [])
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Return tables as a DataFrame."""
+        data = self.get_raw()
+        return pd.DataFrame(data)

--- a/powerbi_api_client/dataset.py
+++ b/powerbi_api_client/dataset.py
@@ -1,0 +1,30 @@
+"""Dataset interactions with the Power BI API."""
+
+from __future__ import annotations
+
+import requests
+import pandas as pd
+
+from .auth import PowerBIAuth
+
+
+class Dataset:
+    """Fetch datasets for a workspace."""
+
+    BASE_URL = "https://api.powerbi.com/v1.0/myorg"
+
+    def __init__(self, auth: PowerBIAuth, workspace_id: str) -> None:
+        self.auth = auth
+        self.workspace_id = workspace_id
+
+    def get_raw(self) -> list[dict]:
+        """Return datasets within the workspace."""
+        url = f"{self.BASE_URL}/groups/{self.workspace_id}/datasets"
+        response = requests.get(url, headers=self.auth.headers())
+        response.raise_for_status()
+        return response.json().get("value", [])
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Return datasets as a DataFrame."""
+        data = self.get_raw()
+        return pd.DataFrame(data)

--- a/powerbi_api_client/utils.py
+++ b/powerbi_api_client/utils.py
@@ -1,0 +1,10 @@
+"""Utility helpers for the Power BI API client."""
+
+from __future__ import annotations
+
+from dotenv import load_dotenv
+
+
+def load_env() -> None:
+    """Load environment variables from a .env file if present."""
+    load_dotenv()

--- a/powerbi_api_client/workspace.py
+++ b/powerbi_api_client/workspace.py
@@ -1,0 +1,29 @@
+"""Workspace interactions with the Power BI API."""
+
+from __future__ import annotations
+
+import requests
+import pandas as pd
+
+from .auth import PowerBIAuth
+
+
+class Workspace:
+    """Fetch and process Power BI workspaces."""
+
+    BASE_URL = "https://api.powerbi.com/v1.0/myorg"
+
+    def __init__(self, auth: PowerBIAuth) -> None:
+        self.auth = auth
+
+    def get_raw(self) -> list[dict]:
+        """Return raw workspace JSON objects."""
+        url = f"{self.BASE_URL}/groups"
+        response = requests.get(url, headers=self.auth.headers())
+        response.raise_for_status()
+        return response.json().get("value", [])
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Return workspace information as a pandas DataFrame."""
+        data = self.get_raw()
+        return pd.DataFrame(data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
-
+msal
+pandas
+python-dotenv
+requests


### PR DESCRIPTION
## Summary
- set up Python modules for Power BI API access
- implement authentication helper using msal
- create Workspace, Dataset and DataModel classes
- provide example usage and update README
- define required packages

## Testing
- `python -m py_compile powerbi_api_client/*.py examples/*.py`
