### PR TITLE
Add pagination helper and fetch_all option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ python examples/example_usage.py
 This will output a table of your Power BI workspaces and datasets using
 `pandas` DataFrames.
 
+All `get_raw` methods accept a `fetch_all` flag. When set to `True`, the
+client automatically handles `$top`/`$skip` pagination and returns all
+records.
+
 ## Extending
 
 The codebase is structured to be easily extended for additional Power BI

--- a/examples/example_usage.py
+++ b/examples/example_usage.py
@@ -1,6 +1,7 @@
 """Example showing basic usage of the Power BI API client."""
 
 from powerbi_api_client import PowerBIAuth, Workspace, Dataset
+import pandas as pd
 
 
 def main() -> None:
@@ -9,14 +10,18 @@ def main() -> None:
 
     # List workspaces
     workspace_client = Workspace(auth)
-    workspaces_df = workspace_client.to_dataframe()
+    # Fetch all workspaces with pagination
+    workspaces = workspace_client.get_raw(fetch_all=True)
+    workspaces_df = pd.DataFrame(workspaces)
     print("Workspaces:")
     print(workspaces_df)
 
     if not workspaces_df.empty:
         workspace_id = workspaces_df.loc[0, "id"]
         dataset_client = Dataset(auth, workspace_id)
-        datasets_df = dataset_client.to_dataframe()
+        # Fetch all datasets within the workspace
+        datasets = dataset_client.get_raw(fetch_all=True)
+        datasets_df = pd.DataFrame(datasets)
         print(f"\nDatasets in workspace {workspace_id}:")
         print(datasets_df)
 

--- a/powerbi_api_client/datamodel.py
+++ b/powerbi_api_client/datamodel.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import requests
 import pandas as pd
 
+from .utils import fetch_paginated
+
 from .auth import PowerBIAuth
 
 
@@ -18,9 +20,20 @@ class DataModel:
         self.workspace_id = workspace_id
         self.dataset_id = dataset_id
 
-    def get_raw(self) -> list[dict]:
-        """Return tables inside the dataset."""
-        url = f"{self.BASE_URL}/groups/{self.workspace_id}/datasets/{self.dataset_id}/tables"
+    def get_raw(self, fetch_all: bool = False) -> list[dict]:
+        """Return tables inside the dataset.
+
+        Parameters
+        ----------
+        fetch_all:
+            When ``True``, paginate through all tables with ``$top`` and
+            ``$skip``.
+        """
+        url = (
+            f"{self.BASE_URL}/groups/{self.workspace_id}/datasets/{self.dataset_id}/tables"
+        )
+        if fetch_all:
+            return fetch_paginated(url, self.auth.headers())
         response = requests.get(url, headers=self.auth.headers())
         response.raise_for_status()
         return response.json().get("value", [])

--- a/powerbi_api_client/dataset.py
+++ b/powerbi_api_client/dataset.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import requests
 import pandas as pd
 
+from .utils import fetch_paginated
+
 from .auth import PowerBIAuth
 
 
@@ -17,9 +19,18 @@ class Dataset:
         self.auth = auth
         self.workspace_id = workspace_id
 
-    def get_raw(self) -> list[dict]:
-        """Return datasets within the workspace."""
+    def get_raw(self, fetch_all: bool = False) -> list[dict]:
+        """Return datasets within the workspace.
+
+        Parameters
+        ----------
+        fetch_all:
+            When ``True``, fetch all datasets by paging with ``$top`` and
+            ``$skip``.
+        """
         url = f"{self.BASE_URL}/groups/{self.workspace_id}/datasets"
+        if fetch_all:
+            return fetch_paginated(url, self.auth.headers())
         response = requests.get(url, headers=self.auth.headers())
         response.raise_for_status()
         return response.json().get("value", [])

--- a/powerbi_api_client/utils.py
+++ b/powerbi_api_client/utils.py
@@ -2,9 +2,29 @@
 
 from __future__ import annotations
 
+from typing import Dict, List
+
+import requests
 from dotenv import load_dotenv
 
 
 def load_env() -> None:
     """Load environment variables from a .env file if present."""
     load_dotenv()
+
+
+def fetch_paginated(url: str, headers: Dict[str, str], top: int = 100) -> List[dict]:
+    """Return all paginated results using $top and $skip parameters."""
+    results: List[dict] = []
+    skip = 0
+    while True:
+        delim = "?" if "?" not in url else "&"
+        paged_url = f"{url}{delim}$top={top}&$skip={skip}"
+        response = requests.get(paged_url, headers=headers)
+        response.raise_for_status()
+        data = response.json().get("value", [])
+        results.extend(data)
+        if len(data) < top:
+            break
+        skip += top
+    return results

--- a/powerbi_api_client/workspace.py
+++ b/powerbi_api_client/workspace.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import requests
 import pandas as pd
 
+from .utils import fetch_paginated
+
 from .auth import PowerBIAuth
 
 
@@ -16,9 +18,18 @@ class Workspace:
     def __init__(self, auth: PowerBIAuth) -> None:
         self.auth = auth
 
-    def get_raw(self) -> list[dict]:
-        """Return raw workspace JSON objects."""
+    def get_raw(self, fetch_all: bool = False) -> list[dict]:
+        """Return raw workspace JSON objects.
+
+        Parameters
+        ----------
+        fetch_all:
+            When ``True``, paginate through all workspaces using ``$top`` and
+            ``$skip`` query parameters.
+        """
         url = f"{self.BASE_URL}/groups"
+        if fetch_all:
+            return fetch_paginated(url, self.auth.headers())
         response = requests.get(url, headers=self.auth.headers())
         response.raise_for_status()
         return response.json().get("value", [])


### PR DESCRIPTION
## Summary
- add `fetch_paginated` helper
- use `fetch_paginated` from `Workspace`, `Dataset` and `DataModel` when `fetch_all=True`
- document pagination option in README
- update example usage to show pagination

## Testing
- `python -m py_compile powerbi_api_client/*.py examples/*.py`