### PR TITLE
Extend example with dataset and dashboard options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Run the example script to list workspaces and datasets:
 python examples/example_usage.py
 ```
 
+You can specify a workspace to list datasets from using the ``--workspace-id``
+flag. You can also print tables for a specific dataset using ``--dataset-id``
+and display dashboards with ``--show-dashboards``:
+
+```bash
+python examples/example_usage.py --workspace-id YOUR_WORKSPACE_ID \
+    --dataset-id YOUR_DATASET_ID --show-dashboards
+```
+
 This will output a table of your Power BI workspaces and datasets using
 `pandas` DataFrames.
 

--- a/examples/example_usage.py
+++ b/examples/example_usage.py
@@ -1,29 +1,71 @@
 """Example showing basic usage of the Power BI API client."""
 
-from powerbi_api_client import PowerBIAuth, Workspace, Dataset
+import argparse
 import pandas as pd
+
+from powerbi_api_client import Dashboard, DataModel, Dataset, PowerBIAuth, Workspace
+
+
+def parse_args() -> argparse.Namespace:
+    """Return command line arguments for the example script."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--workspace-id",
+        help="Fetch datasets for the given workspace id. If omitted, the first workspace is used.",
+    )
+    parser.add_argument(
+        "--dataset-id",
+        help=(
+            "Show tables for the given dataset id. If omitted, the first dataset "
+            "in the workspace is used."
+        ),
+    )
+    parser.add_argument(
+        "--show-dashboards",
+        action="store_true",
+        help="Display dashboards for the selected workspace.",
+    )
+    return parser.parse_args()
 
 
 def main() -> None:
+    """Run the example using optional command line arguments."""
+    args = parse_args()
+
     # Load credentials from environment variables
     auth = PowerBIAuth.from_env()
 
     # List workspaces
     workspace_client = Workspace(auth)
-    # Fetch all workspaces with pagination
     workspaces = workspace_client.get_raw(fetch_all=True)
     workspaces_df = pd.DataFrame(workspaces)
     print("Workspaces:")
     print(workspaces_df)
 
     if not workspaces_df.empty:
-        workspace_id = workspaces_df.loc[0, "id"]
+        workspace_id = args.workspace_id or workspaces_df.loc[0, "id"]
         dataset_client = Dataset(auth, workspace_id)
-        # Fetch all datasets within the workspace
         datasets = dataset_client.get_raw(fetch_all=True)
         datasets_df = pd.DataFrame(datasets)
         print(f"\nDatasets in workspace {workspace_id}:")
         print(datasets_df)
+
+        if datasets_df.empty:
+            return
+
+        dataset_id = args.dataset_id or datasets_df.loc[0, "id"]
+        model_client = DataModel(auth, workspace_id, dataset_id)
+        tables = model_client.get_raw(fetch_all=True)
+        tables_df = pd.DataFrame(tables)
+        print(f"\nTables in dataset {dataset_id}:")
+        print(tables_df)
+
+        if args.show_dashboards:
+            dashboard_client = Dashboard(auth, workspace_id)
+            dashboards = dashboard_client.get_raw(fetch_all=True)
+            dashboards_df = pd.DataFrame(dashboards)
+            print(f"\nDashboards in workspace {workspace_id}:")
+            print(dashboards_df)
 
 
 if __name__ == "__main__":

--- a/powerbi_api_client/__init__.py
+++ b/powerbi_api_client/__init__.py
@@ -4,6 +4,7 @@ from .auth import PowerBIAuth
 from .workspace import Workspace
 from .dataset import Dataset
 from .datamodel import DataModel
+from .dashboard import Dashboard
 from . import utils
 
 __all__ = [
@@ -11,5 +12,6 @@ __all__ = [
     "Workspace",
     "Dataset",
     "DataModel",
+    "Dashboard",
     "utils",
 ]

--- a/powerbi_api_client/dashboard.py
+++ b/powerbi_api_client/dashboard.py
@@ -1,0 +1,39 @@
+"""Dashboard interactions with the Power BI API."""
+
+from __future__ import annotations
+
+import requests
+import pandas as pd
+
+from .utils import fetch_paginated
+from .auth import PowerBIAuth
+
+
+class Dashboard:
+    """Fetch dashboards for a workspace."""
+
+    BASE_URL = "https://api.powerbi.com/v1.0/myorg"
+
+    def __init__(self, auth: PowerBIAuth, workspace_id: str) -> None:
+        self.auth = auth
+        self.workspace_id = workspace_id
+
+    def get_raw(self, fetch_all: bool = False) -> list[dict]:
+        """Return dashboards within the workspace.
+
+        Parameters
+        ----------
+        fetch_all:
+            When ``True``, fetch all dashboards using ``$top`` and ``$skip``.
+        """
+        url = f"{self.BASE_URL}/groups/{self.workspace_id}/dashboards"
+        if fetch_all:
+            return fetch_paginated(url, self.auth.headers())
+        response = requests.get(url, headers=self.auth.headers())
+        response.raise_for_status()
+        return response.json().get("value", [])
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Return dashboards as a DataFrame."""
+        data = self.get_raw()
+        return pd.DataFrame(data)


### PR DESCRIPTION
## Summary
- update README with new CLI instructions
- add Dashboard class for workspace dashboards
- export Dashboard from package
- extend example script to show tables and dashboards

## Testing
- `python -m py_compile powerbi_api_client/*.py examples/*.py`
