### PR TITLE
Add JSON export helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,4 @@ These guidelines apply to the entire repository.
   ```bash
   python -m py_compile powerbi_api_client/*.py examples/*.py
   ```
+* JSON output files should be stored in the ``json_data`` directory.

--- a/README.md
+++ b/README.md
@@ -62,3 +62,16 @@ endpoints. Each entity class contains two core methods:
 
 Additional helpers and endpoints can be implemented following the same
 pattern.
+
+## Saving Output
+
+Use ``powerbi_api_client.utils.save_json`` to write any Python object to a
+JSON file. The helper creates a ``json_data`` directory by default and accepts a
+custom file name:
+
+```python
+from powerbi_api_client.utils import save_json
+
+data = {"hello": "world"}
+save_json(data, "example.json")
+```

--- a/examples/example_usage.py
+++ b/examples/example_usage.py
@@ -3,7 +3,14 @@
 import argparse
 import pandas as pd
 
-from powerbi_api_client import Dashboard, DataModel, Dataset, PowerBIAuth, Workspace
+from powerbi_api_client import (
+    Dashboard,
+    DataModel,
+    Dataset,
+    PowerBIAuth,
+    Workspace,
+    utils,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -25,6 +32,12 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Display dashboards for the selected workspace.",
     )
+    parser.add_argument(
+        "--save-json",
+        help=(
+            "Base file name for saving fetched data to the json_data folder."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -41,6 +54,8 @@ def main() -> None:
     workspaces_df = pd.DataFrame(workspaces)
     print("Workspaces:")
     print(workspaces_df)
+    if args.save_json:
+        utils.save_json(workspaces, f"{args.save_json}_workspaces.json")
 
     if not workspaces_df.empty:
         workspace_id = args.workspace_id or workspaces_df.loc[0, "id"]
@@ -49,6 +64,8 @@ def main() -> None:
         datasets_df = pd.DataFrame(datasets)
         print(f"\nDatasets in workspace {workspace_id}:")
         print(datasets_df)
+        if args.save_json:
+            utils.save_json(datasets, f"{args.save_json}_datasets.json")
 
         if datasets_df.empty:
             return
@@ -59,6 +76,8 @@ def main() -> None:
         tables_df = pd.DataFrame(tables)
         print(f"\nTables in dataset {dataset_id}:")
         print(tables_df)
+        if args.save_json:
+            utils.save_json(tables, f"{args.save_json}_tables.json")
 
         if args.show_dashboards:
             dashboard_client = Dashboard(auth, workspace_id)
@@ -66,6 +85,8 @@ def main() -> None:
             dashboards_df = pd.DataFrame(dashboards)
             print(f"\nDashboards in workspace {workspace_id}:")
             print(dashboards_df)
+            if args.save_json:
+                utils.save_json(dashboards, f"{args.save_json}_dashboards.json")
 
 
 if __name__ == "__main__":

--- a/powerbi_api_client/utils.py
+++ b/powerbi_api_client/utils.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Any, Dict, List
+
+import json
+from pathlib import Path
 
 import requests
 from dotenv import load_dotenv
@@ -28,3 +31,31 @@ def fetch_paginated(url: str, headers: Dict[str, str], top: int = 100) -> List[d
             break
         skip += top
     return results
+
+
+def save_json(data: Any, file_name: str, folder: str = "json_data") -> str:
+    """Write the provided data to a JSON file.
+
+    The target directory will be created if it does not already exist.
+
+    Parameters
+    ----------
+    data:
+        Python object serialisable by ``json``.
+    file_name:
+        File name for the JSON output.
+    folder:
+        Directory in which to store the JSON file.
+
+    Returns
+    -------
+    str
+        The path to the written file.
+    """
+
+    directory = Path(folder)
+    directory.mkdir(parents=True, exist_ok=True)
+    file_path = directory / file_name
+    with file_path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    return str(file_path)


### PR DESCRIPTION
## Summary
- add `save_json` helper to write data to a file
- document JSON saving feature
- update agent instructions
- support `--save-json` flag in `example_usage.py`
- include json_data folder

## Testing
- `python -m py_compile powerbi_api_client/*.py examples/*.py`